### PR TITLE
Add 'https' to the S3 endpoint

### DIFF
--- a/manifests/infra/argo-workflows/artifact-repository-configmap.yaml
+++ b/manifests/infra/argo-workflows/artifact-repository-configmap.yaml
@@ -8,7 +8,7 @@ data:
   s3-artifact-repository: |
     s3: 
       bucket: argo-artifact-repository
-      endpoint: s3-a.zhw.cloud.switch.ch
+      endpoint: https://s3-a.zhw.cloud.switch.ch
       insecure: true
       accessKeySecret:
         name: artifacts-s3


### PR DESCRIPTION
I believe argo does default to `http` scheme unless otherwise specified.